### PR TITLE
[RND-1080] NES 릴리즈 이름 변경

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -910,7 +910,7 @@ def main():
     parser, parsed_args, childargs = parse_cmdargs()
 
     if parsed_args.version:
-        print('ceph version {0} ({1}) {2} ({3})'.format(
+        print('ne-storage version {0} ({1}) {2} ({3})'.format(
             CEPH_GIT_NICE_VER,
             CEPH_GIT_VER,
             CEPH_RELEASE_NAME,

--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
-14
-nautilus
+15
+apex
 stable

--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -73,6 +73,8 @@ const char *ceph_osd_state_name(int s)
 const char *ceph_release_name(int r)
 {
 	switch (r) {
+	case CEPH_RELEASE_APEX:
+		return "apex";
 	case CEPH_RELEASE_ARGONAUT:
 		return "argonaut";
 	case CEPH_RELEASE_BOBTAIL:
@@ -112,6 +114,9 @@ int ceph_release_from_name(const char *s)
 {
 	if (!s) {
 		return -1;
+	}
+	if (strcmp(s, "apex") == 0) {
+		return CEPH_RELEASE_APEX;
 	}
 	if (strcmp(s, "nautilus") == 0) {
 		return CEPH_RELEASE_NAUTILUS;

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -199,7 +199,8 @@ extern const char *ceph_osd_state_name(int s);
 #define CEPH_RELEASE_LUMINOUS   12
 #define CEPH_RELEASE_MIMIC      13
 #define CEPH_RELEASE_NAUTILUS   14
-#define CEPH_RELEASE_MAX        15  /* highest + 1 */
+#define CEPH_RELEASE_APEX       15
+#define CEPH_RELEASE_MAX        16  /* highest + 1 */
 
 extern const char *ceph_release_name(int r);
 extern int ceph_release_from_name(const char *s);


### PR DESCRIPTION
* NES는 1.x.y 버전에 Apex라는 릴리즈명이 있다.
* 이를 코드에 반영하는 작업
* 작업 전의 버전: ceph version 1.0.1.nes (....) nautilus (stable)
* 작업 후의 버전: ne-storage version 1.0.1.nes (....) apex (stable)
