### PR TITLE
[RND-1082] revert NES version prefix to "ceph" (v1.0.0.nes)

### DIFF
--- a/src/ceph.in
+++ b/src/ceph.in
@@ -910,7 +910,7 @@ def main():
     parser, parsed_args, childargs = parse_cmdargs()
 
     if parsed_args.version:
-        print('ne-storage version {0} ({1}) {2} ({3})'.format(
+        print('ceph version {0} ({1}) {2} ({3})'.format(
             CEPH_GIT_NICE_VER,
             CEPH_GIT_VER,
             CEPH_RELEASE_NAME,

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -41,7 +41,7 @@ const char *git_version_to_str(void)
 std::string const pretty_version_to_str(void)
 {
   std::ostringstream oss;
-  oss << "ne-storage version " << CEPH_GIT_NICE_VER
+  oss << "ceph version " << CEPH_GIT_NICE_VER
       << " (" << STRINGIFY(CEPH_GIT_VER) << ") "
       << ceph_release_name(CEPH_RELEASE)
       << " (" << CEPH_RELEASE_TYPE << ")";


### PR DESCRIPTION
* NES의 버전 표기 현재는 "ne-storage x.y.z.nes .... apex (stable)"와 같음
* 바이너리를 비롯한 모든 명칭을 nes로 바꾸지 않을 것이고 버전 뒤에 (.nes) 표기로 충분히 nes 버전의 ceph인지 구분이 됨
* "ne-storage" 문자열이 버전 뒤 .nes와 중복되는 정보를 표시하는 듯하기도 함
* 위와 같은 이유로 "ne-storage" 문자열을 ceph로 다시 되돌리는 작업