### PR TITLE
[RND-1082] revert NES version prefix to "ceph" (v1.0.3.nes)

### DIFF
--- a/cmake/modules/BuildBoost.cmake
+++ b/cmake/modules/BuildBoost.cmake
@@ -147,7 +147,7 @@ function(do_build_boost version)
     set(boost_sha256 59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722)
     string(REPLACE "." "_" boost_version_underscore ${boost_version} )
     set(boost_url 
-      https://dl.bintray.com/boostorg/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2)
+      https://boostorg.jfrog.io/artifactory/main/release/${boost_version}/source/boost_${boost_version_underscore}.tar.bz2)
     if(CMAKE_VERSION VERSION_GREATER 3.7)
       set(boost_url
         "${boost_url} http://downloads.sourceforge.net/project/boost/boost/${boost_version}/boost_${boost_version_underscore}.tar.bz2")

--- a/make-dist
+++ b/make-dist
@@ -140,6 +140,7 @@ tar cvf $outfile.version.tar $outfile/src/.git_version $outfile/ceph.spec $outfi
 # at the three URLs referenced below (may involve uploading to download.ceph.com)
 boost_version=1.72.0
 download_boost $boost_version 59c9b274bc451cf91a9ba1dd2c7fdcaf5d60b1b3aa83f2c9fa143417cc660722 \
+               https://boostorg.jfrog.io/artifactory/main/release/$boost_version/source \
                https://dl.bintray.com/boostorg/release/$boost_version/source \
                https://downloads.sourceforge.net/project/boost/boost/$boost_version \
                https://download.ceph.com/qa

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -910,7 +910,7 @@ def main():
     parser, parsed_args, childargs = parse_cmdargs()
 
     if parsed_args.version:
-        print('ne-storage version {0} ({1}) {2} ({3})'.format(
+        print('ceph version {0} ({1}) {2} ({3})'.format(
             CEPH_GIT_NICE_VER,
             CEPH_GIT_VER,
             CEPH_RELEASE_NAME,

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -910,7 +910,7 @@ def main():
     parser, parsed_args, childargs = parse_cmdargs()
 
     if parsed_args.version:
-        print('ceph version {0} ({1}) {2} ({3})'.format(
+        print('ne-storage version {0} ({1}) {2} ({3})'.format(
             CEPH_GIT_NICE_VER,
             CEPH_GIT_VER,
             CEPH_RELEASE_NAME,

--- a/src/ceph.in
+++ b/src/ceph.in
@@ -914,7 +914,7 @@ def main():
             CEPH_GIT_NICE_VER,
             CEPH_GIT_VER,
             CEPH_RELEASE_NAME,
-            CEPH_RELEASE_TYPE))  # noqa
+            CEPH_RELEASE_TYPE))   # noqa
         return 0
 
     global verbose

--- a/src/ceph_release
+++ b/src/ceph_release
@@ -1,3 +1,3 @@
-14
-nautilus
+15
+apex
 stable

--- a/src/common/ceph_strings.cc
+++ b/src/common/ceph_strings.cc
@@ -73,6 +73,8 @@ const char *ceph_osd_state_name(int s)
 const char *ceph_release_name(int r)
 {
 	switch (r) {
+	case CEPH_RELEASE_APEX:
+		return "apex";
 	case CEPH_RELEASE_ARGONAUT:
 		return "argonaut";
 	case CEPH_RELEASE_BOBTAIL:
@@ -112,6 +114,9 @@ int ceph_release_from_name(const char *s)
 {
 	if (!s) {
 		return -1;
+	}
+	if (strcmp(s, "apex") == 0) {
+		return CEPH_RELEASE_APEX;
 	}
 	if (strcmp(s, "nautilus") == 0) {
 		return CEPH_RELEASE_NAUTILUS;

--- a/src/common/version.cc
+++ b/src/common/version.cc
@@ -41,7 +41,7 @@ const char *git_version_to_str(void)
 std::string const pretty_version_to_str(void)
 {
   std::ostringstream oss;
-  oss << "ne-storage version " << CEPH_GIT_NICE_VER
+  oss << "ceph version " << CEPH_GIT_NICE_VER
       << " (" << STRINGIFY(CEPH_GIT_VER) << ") "
       << ceph_release_name(CEPH_RELEASE)
       << " (" << CEPH_RELEASE_TYPE << ")";

--- a/src/include/rados.h
+++ b/src/include/rados.h
@@ -199,7 +199,8 @@ extern const char *ceph_osd_state_name(int s);
 #define CEPH_RELEASE_LUMINOUS   12
 #define CEPH_RELEASE_MIMIC      13
 #define CEPH_RELEASE_NAUTILUS   14
-#define CEPH_RELEASE_MAX        15  /* highest + 1 */
+#define CEPH_RELEASE_APEX       15
+#define CEPH_RELEASE_MAX        16  /* highest + 1 */
 
 extern const char *ceph_release_name(int r);
 extern int ceph_release_from_name(const char *s);

--- a/src/test/librgw_file.cc
+++ b/src/test/librgw_file.cc
@@ -202,7 +202,7 @@ TEST(LibRGW, GETATTR_OBJECTS) {
   }
 }
 
-TEST(LibRGW, CLEANUP) {
+TEST(LibRGW, CLEANUP1) {
   int ret = 0;
   using std::get;
 

--- a/src/test/librgw_file_aw.cc
+++ b/src/test/librgw_file_aw.cc
@@ -334,7 +334,7 @@ TEST(LibRGW, DELETE_OBJECT) {
   }
 }
 
-TEST(LibRGW, CLEANUP) {
+TEST(LibRGW, CLEANUP4) {
   int ret;
   if (object_fh) {
     ret = rgw_fh_rele(fs, object_fh, RGW_FH_RELE_FLAG_NONE);

--- a/src/test/librgw_file_cd.cc
+++ b/src/test/librgw_file_cd.cc
@@ -119,7 +119,7 @@ TEST(LibRGW, DELETE_BUCKET_MULTI) {
   }
 }
 
-TEST(LibRGW, CLEANUP) {
+TEST(LibRGW, CLEANUP3) {
   // do nothing
 }
 

--- a/src/test/librgw_file_gp.cc
+++ b/src/test/librgw_file_gp.cc
@@ -372,7 +372,7 @@ TEST(LibRGW, DELETE_OBJECT) {
   }
 }
 
-TEST(LibRGW, CLEANUP) {
+TEST(LibRGW, CLEANUP2) {
   if (do_readv) {
     // release resources
     ASSERT_NE(uio->uio_rele, nullptr);

--- a/src/test/librgw_file_marker.cc
+++ b/src/test/librgw_file_marker.cc
@@ -393,7 +393,7 @@ TEST(LibRGW, MARKER1_OBJ_CLEANUP)
   marker_objs.clear();
 }
 
-TEST(LibRGW, CLEANUP) {
+TEST(LibRGW, CLEANUP6) {
   int rc;
 
   if (do_marker1) {

--- a/src/test/librgw_file_nfsns.cc
+++ b/src/test/librgw_file_nfsns.cc
@@ -1079,7 +1079,7 @@ TEST(LibRGW, MARKER1_OBJ_CLEANUP)
   marker_objs.clear();
 }
 
-TEST(LibRGW, CLEANUP) {
+TEST(LibRGW, CLEANUP5) {
   int rc;
 
   if (do_marker1) {


### PR DESCRIPTION
* NES의 버전 표기 현재는 "ne-storage x.y.z.nes .... apex (stable)"와 같음
* 바이너리를 비롯한 모든 명칭을 nes로 바꾸지 않을 것이고 버전 뒤에 (.nes) 표기로 충분히 nes 버전의 ceph인지 구분이 됨
* "ne-storage" 문자열이 버전 뒤 .nes와 중복되는 정보를 표시하는 듯하기도 함
* 위와 같은 이유로 "ne-storage" 문자열을 ceph로 다시 되돌리는 작업