### PR TITLE
[RND-1083] atlassian_statuspage mgr 모듈의 "Too many update" 이슈 해결

### DIFF
--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -272,7 +272,7 @@ class AtlassianStatuspage(MgrModule):
         if 400 <= search_response.status_code < 600:
             return self._health_check_msg(
                 'REST_ERROR',
-                'unable to send status info to statuspage component',
+                'unable to get unresolved component incidents from the statuspage',
                 "%s (status code %d)" % (search_response_text, search_response.status_code))
 
         try:
@@ -328,7 +328,22 @@ class AtlassianStatuspage(MgrModule):
         self.log.debug("request url is '%s'" % request_url)
         self.log.debug("response of rest: [%d] %s" % (response.status_code, response.text.encode('utf8')))
 
-        if 400 <= response.status_code < 600:
+        if response.status_code == 422: # Too many incident updates
+            data['incident']['status'] = "resolved"
+            data['incident'][ 'body' ] = "Too many updates in incident. Relsolve this incident and continue in new incident."
+            request_url = self.rest_url + "/v1/pages/%s/incidents/%s" % (self.page_id, incident_id)
+            response = requests.put(request_url, headers=headers, json=data)
+            if 400 <= response.status_code < 600:
+                return self._health_check_msg(
+                    'REST_ERROR',
+                    'unable to resolve incident',
+                    "%s (status code %d)" % (response.text.encode('utf8'), response.status_code))
+            else:
+                return self._health_check_msg(
+                    'REST_WARN',
+                    "too many updates in incident. resolve incident %s and continue in new incident." % incident_id,
+                    "%s (status code %d)" % (response.text.encode('utf8'), response.status_code))
+        elif 400 <= response.status_code < 600:
             return self._health_check_msg(
                 'REST_ERROR',
                 'unable to send status info to statuspage component',

--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -328,10 +328,9 @@ class AtlassianStatuspage(MgrModule):
         self.log.debug("request url is '%s'" % request_url)
         self.log.debug("response of rest: [%d] %s" % (response.status_code, response.text.encode('utf8')))
 
-        if response.status_code == 422: # Too many incident updates
+        if incident_id != '' and response.status_code == 422: # Too many incident updates
             data['incident']['status'] = "resolved"
             data['incident'][ 'body' ] = "Too many updates in incident. Relsolve this incident and continue in new incident."
-            request_url = self.rest_url + "/v1/pages/%s/incidents/%s" % (self.page_id, incident_id)
             response = requests.put(request_url, headers=headers, json=data)
             if 400 <= response.status_code < 600:
                 return self._health_check_msg(

--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -272,7 +272,7 @@ class AtlassianStatuspage(MgrModule):
         if 400 <= search_response.status_code < 600:
             return self._health_check_msg(
                 'REST_ERROR',
-                'unable to get unresolved component incidents from the statuspage',
+                'unable to get unresolved incidents from the statuspage',
                 "%s (status code %d)" % (search_response_text, search_response.status_code))
 
         try:

--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -328,7 +328,9 @@ class AtlassianStatuspage(MgrModule):
         self.log.debug("request url is '%s'" % request_url)
         self.log.debug("response of rest: [%d] %s" % (response.status_code, response.text.encode('utf8')))
 
-        if incident_id != '' and response.status_code == 422: # Too many incident updates
+        if incident_id != '' \
+          and response.status_code == 422 \
+          and "Too many incident updates" in response.text.encode('utf8'):
             data['incident']['status'] = "resolved"
             data['incident'][ 'body' ] = "Too many updates in incident. Relsolve this incident and continue in new incident."
             response = requests.put(request_url, headers=headers, json=data)
@@ -338,10 +340,7 @@ class AtlassianStatuspage(MgrModule):
                     'unable to resolve incident',
                     "%s (status code %d)" % (response.text.encode('utf8'), response.status_code))
             else:
-                return self._health_check_msg(
-                    'REST_WARN',
-                    "too many updates in incident. resolve incident %s and continue in new incident." % incident_id,
-                    "%s (status code %d)" % (response.text.encode('utf8'), response.status_code))
+                return self._send_msg_to_atlassian_statuspage_through_rest(status, diff)
         elif 400 <= response.status_code < 600:
             return self._health_check_msg(
                 'REST_ERROR',


### PR DESCRIPTION
* atlassian_statuspage mgr 모듈은 클러스터의 상태를 주기적으로 체크하여 이상 상태의 변화를  atlassian statuspage로 갱신해주는 역할을 한다.
* 갱신된 내용은 statuspage의 incident라는 항목에 모아서 쌓게 되는데 이 incident에 내용을 갱신하는 최대 횟수가 존재한다.
* incident 내용 갱신 횟수에 제한이 걸리면 atlassian_statuspage 모듈이 더이상 상태 갱신을 못하고 다음과 같은 에러 메시지를 띄우게 된다. 
`ATLASSIAN_STATUSPAGE_REST_ERROR [Module 'atlassian_statuspage'] unable to send status info to statuspage component
    {"error":["Too many incident updates. Please resolve this incident and open a new one."]} (status code 422)
`
* 위와 같은 이슈를 해결하기 위한 작업