### PR TITLE
[RND-1084] atlassian_statuspage mgr 모듈의 "exceed character limit" 이슈 해결

### DIFF
--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -308,12 +308,16 @@ class AtlassianStatuspage(MgrModule):
         incident_status = "investigating"
         if comp_status == "operational" : incident_status = "resolved"
 
+        data_body = self._msg_format_contents(status, diff)
+        if len(data_body) > 24999: # body length limit is '25000'
+            data_body = data_body[:24995] + " ..."
+
         data = {
             'incident': {
                 'components': { self.component_id: comp_status },
                 'component_ids': [ self.component_id ],
                 'status': incident_status,
-                'body': self._msg_format_contents(status, diff)[:24999], # body length limit is '25000'
+                'body': data_body,
             }
         }
 

--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -313,7 +313,7 @@ class AtlassianStatuspage(MgrModule):
                 'components': { self.component_id: comp_status },
                 'component_ids': [ self.component_id ],
                 'status': incident_status,
-                'body': self._msg_format_contents(status, diff),
+                'body': self._msg_format_contents(status, diff)[:24999], # body length limit is '25000'
             }
         }
 


### PR DESCRIPTION
* atlassian_statuspage mgr 모듈은 클러스터의 상태를 주기적으로 체크하여 이상 상태의 변화를  atlassian statuspage로 갱신해주는 역할을 한다.
* 갱신된 내용은 statuspage의 incident라는 항목에 모아서 쌓게 되는데 이 incident 내용의 최대 글자 수가 존재한다.
* incident 내용의 글자 수 제한에 걸리면 atlassian_statuspage 모듈이 더이상 상태 갱신을 못하고 다음과 같은 에러 메시지를 띄우게 된다.
`
[WARN] ATLASSIAN_STATUSPAGE_REST_ERROR: [Module 'atlassian_statuspage'] unable to send status info to statuspage component
{"error":["Body of update text exceeds the character limit for incident updates (25,000 characters). Reenter your update with fewer characters."]} (status code 422)
`
* 위와 같은 이슈를 해결하기 위한 작업