### PR TITLE
[RND-1085] atlassian_statuspage mgr 모듈에 include_detail 설정 추가

### DIFF
--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -34,6 +34,13 @@ class AtlassianStatuspage(MgrModule):
             'runtime': True,
         },
         {
+            'name': 'include_detail',
+            'type': 'bool',
+            'default': False,
+            'desc': 'Whether message contents include detail or not',
+            'runtime': True,
+        },
+        {
             'name': 'page_id',
             'default': '',
             'desc': 'page ID of Atlassian statuspage. (used only rest mode)',
@@ -215,8 +222,11 @@ class AtlassianStatuspage(MgrModule):
             code=code,
             sev=stat['severity'].split('_')[1],
             summary=stat['summary']['message'])
-        for detail in stat['detail']:
-            msg += '        {}\n'.format(detail['message'])
+
+        if self.include_detail:
+            for detail in stat['detail']:
+                msg += '        {}\n'.format(detail['message'])
+
         return msg
 
     def _msg_format_contents(self, status, diff):


### PR DESCRIPTION
* altassian_statuspage mgr 모듈은 클러스터의 이상 상태를 statuspage에 갱신해주어 한눈에 클러스터의 상태를 알 수 있도록 해준다.
* altassian_statuspage mgr 모듈이 갱신해주는 내용에는 디테일한 내용들도 들어가는데, 이렇게 되면 상태를 표시하는 내용이 너무 길어진다.
* altassian_statuspage mgr 모듈을 사용해 본 결과 내용이 너무 길어 보기도 힘들고 문제 파악에 시간이 오히려 더 걸리게 되는 문제가 있다는 것을 알게 되었다.
* 디테일한 내용들은 문제 상황에 직접 클러스터에서 확인하고 분석해봐야 하는 성격이라는 판단도 있음
* 위와 같은 이유로 디테일한 내용을 메시지에 포함할 것인지 여부를 결정할 수 있는 옵션을 추가하도록 "include_detail" 설정을 altassian_statuspage mgr 모듈에 추가하는 일감.
* "include_detail" 값이 True 이면 디테일한 내용을 메시지에 포함하고, 기본값은 False로 한다.