### PR TITLE
[RND-1086] 로컬 빌드 대상에서 임시 컴파일 된 dashboard 파일을 제거

### DIFF
--- a/bin/git-archive-all.sh
+++ b/bin/git-archive-all.sh
@@ -221,7 +221,15 @@ else
     cp -rf $OLD_PWD $TMPDIR/$dir_prefix
 
     pushd $TMPDIR > /dev/null
-    $TARCMD --exclude="RPMS" --exclude=".*.sw*" --exclude="tags" --exclude="*.pyc" --exclude="*.pyo" -cf ./$OLD_PWD_BASE.$FORMAT $dir_prefix
+    $TARCMD \
+        --exclude="src/pybind/mgr/dashboard/frontend/node_modules" \
+        --exclude="RPMS"   \
+        --exclude=".*.sw*" \
+        --exclude="tags"   \
+        --exclude="*.pyc"  \
+        --exclude="*.pyo"  \
+        -cf ./$OLD_PWD_BASE.$FORMAT $dir_prefix
+
     popd > /dev/null
 
     if [ $(tar tf $TMPDIR/$OLD_PWD_BASE.$FORMAT |grep "$dir_prefix/.git/$" |wc -l) -gt 0 ]; then


### PR DESCRIPTION
* nes를 빌드하는 과정에서는 컴파일이 필요한 대시보드 파일을 만들기 위해 임시로 컴파일된 파일을 생성한다.
* 이 파일들이 빌드 대상으로 포함되면 rpm 패키지 제작시 다음과 같은 에러가 출력되며 실패한다.
`Arch dependent binaries in noarch package`
* 로컬 소스를 대상으로 빌드를 진행하면 이 임시 컴파일된 파일도 빌드 대상에 포함되어 rpm 패키지 제작이 실패하게 된다.
* 이러한 문제를 회피하기 위해 임시 컴파일 된 파일을 빌드 대상에서 제외하는 작업