### PR TITLE
[RND-1095] atlas 데이터 계보 관리 시스템의 인스턴스 검색 방법 변경

### DIFF
--- a/src/rgw/rgw_lineage_atlas_rest.h
+++ b/src/rgw/rgw_lineage_atlas_rest.h
@@ -18,12 +18,12 @@ private:
     vector<string> & out,
     const string qualified_name,
     const string type_name = string(),
-    bool execlude_deleted_entities = true);
+    bool exclude_deleted_entities = true);
 
   bool is_entity_exist_with_qname(
     const string qualified_name,
     const string type_name = string(),
-    bool execlude_deleted_entities = true);
+    bool exclude_deleted_entities = true);
 
   const string extract_guid_from_entity(const string entity_str);
 
@@ -31,7 +31,7 @@ private:
     string& guid,
     const string qualified_name,
     const string type_name = string(),
-    bool execlude_deleted_entities = true);
+    bool exclude_deleted_entities = true);
 
   int query_attribute_value(
     string& value,
@@ -48,7 +48,7 @@ private:
   int create_object(lineage_req * const lr);
 
 public:
-  RGWLineageAtlasRest(CephContext* const _cct): RGWLineageAtlasImpl(_cct) {} 
+  RGWLineageAtlasRest(CephContext* const _cct): RGWLineageAtlasImpl(_cct) {}
 
   int atlas_init_definition() override;
   int atlas_bucket_creation(lineage_req * const lr) override;


### PR DESCRIPTION
* NES는 atlas와 연동하여 데이터 계보를 기록할 수 있다.
 * 이 과정에서 atlas 인스턴스를 검색하는 경우가 있는데, 이때 검색 결과에 필요 없는 항목이 딸려온다.
   * s3://bucket4를 검색하면, ["s3://bucket4", "s3://bucket1", "s3://bucket2", "s3://bucket3", "s3://bucket5"] 와 같이 모든 버킷이 검색 결과로 반환됨
 * 검색 대상과 비슷한 인스턴스가 가장 앞에 오고 검색 결과의 제일 앞의 인스턴스를 활용하는 atlas 데이터 계보 연동 기능의 동작 특성상 정상적인 경우에는 의도한 대로 동작한다.
 * 문제는 검색 대상 인스턴스가 없는 경우인데, 이러한 경우 모든 인스턴스가 검색 결과로 반환된다. -> 이로인해 의도하지 않은 인스턴스에 조작이 가해질 수 있고, 없는 인스턴스를 자동으로 생성하는 루틴이 동작하지 않게된다.
 * 위와 같은 문제를 해결하기 위해 NES가 atlas의 인스턴스를 검색하는 방식을 변경하는 PR