### PR TITLE
[RND-1236] NES의 rados 라이브러리에 JNI가 포함되면서 환경변수를 요구하는 이슈 해결

### DIFF
--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1279,7 +1279,7 @@ install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_sysconfdir}/sysconfig/ceph
 %if 0%{?suse_version}
 install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_fillupdir}/sysconfig.%{name}
 %endif
-install -m 0644 -D etc/pofile.d/librados.sh %{buildroot}%{_sysconfdir}/pofile.d/librados.sh
+install -m 0644 -D etc/profile.d/librados.sh %{buildroot}%{_sysconfdir}/profile.d/librados.sh
 install -m 0644 -D systemd/ceph.tmpfiles.d %{buildroot}%{_tmpfilesdir}/ceph-common.conf
 install -m 0644 -D systemd/50-ceph.preset %{buildroot}%{_libexecdir}/systemd/system-preset/50-ceph.preset
 mkdir -p %{buildroot}%{_sbindir}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -1279,6 +1279,7 @@ install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_sysconfdir}/sysconfig/ceph
 %if 0%{?suse_version}
 install -m 0644 -D etc/sysconfig/ceph %{buildroot}%{_fillupdir}/sysconfig.%{name}
 %endif
+install -m 0644 -D etc/pofile.d/librados.sh %{buildroot}%{_sysconfdir}/pofile.d/librados.sh
 install -m 0644 -D systemd/ceph.tmpfiles.d %{buildroot}%{_tmpfilesdir}/ceph-common.conf
 install -m 0644 -D systemd/50-ceph.preset %{buildroot}%{_libexecdir}/systemd/system-preset/50-ceph.preset
 mkdir -p %{buildroot}%{_sbindir}

--- a/ceph.spec.in
+++ b/ceph.spec.in
@@ -649,7 +649,6 @@ Requires:	ceph-selinux = %{_epoch_prefix}%{version}-%{release}
 Requires:	librados2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	librgw2 = %{_epoch_prefix}%{version}-%{release}
 Requires:	librgw2 = %{_epoch_prefix}%{version}-%{release}
-Requires:	java
 %if 0%{?rhel} || 0%{?fedora}
 Requires:	mailcap
 %endif
@@ -696,6 +695,7 @@ Group:		System/Libraries
 %if 0%{?rhel} || 0%{?fedora}
 Obsoletes:	ceph-libs < %{_epoch_prefix}%{version}-%{release}
 %endif
+Requires:	java
 %description -n librados2
 RADOS is a reliable, autonomic distributed object storage cluster
 developed as part of the Ceph distributed storage system. This is a
@@ -1992,8 +1992,11 @@ fi
 %{_libdir}/librados_tp.so.*
 %endif
 %dir %{_sysconfdir}/ceph
+%{_sysconfdir}/profile.d/librados.sh
 
-%post -n librados2 -p /sbin/ldconfig
+%post -n librados2
+/sbin/ldconfig
+source %{_sysconfdir}/profile.d/librados.sh
 
 %postun -n librados2 -p /sbin/ldconfig
 

--- a/etc/profile.d/librados.sh
+++ b/etc/profile.d/librados.sh
@@ -1,0 +1,7 @@
+jni_ld_library="/usr/lib/jvm/jre/lib/amd64/server:/usr/lib/jvm/jre/lib/amd64:/usr/lib/jvm/jre/lib:/usr/lib/jvm/jre/lib/server"
+
+if [ "x" == "x${LD_LIBRARY_PATH}" ]; then
+  export LD_LIBRARY_PATH=${jni_ld_library}
+else
+  export LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${jni_ld_library}
+fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -606,6 +606,10 @@ install(PROGRAMS
   DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/init.d
   RENAME ceph)
 
+install(DIRECTORY
+  ${CMAKE_SOURCE_DIR}/profile.d
+  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
+
 install(FILES
   ${CMAKE_SOURCE_DIR}/share/id_rsa_drop.ceph.com
   ${CMAKE_SOURCE_DIR}/share/id_rsa_drop.ceph.com.pub

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -606,10 +606,6 @@ install(PROGRAMS
   DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/init.d
   RENAME ceph)
 
-install(DIRECTORY
-  ${CMAKE_SOURCE_DIR}/profile.d
-  DESTINATION ${CMAKE_INSTALL_SYSCONFDIR})
-
 install(FILES
   ${CMAKE_SOURCE_DIR}/share/id_rsa_drop.ceph.com
   ${CMAKE_SOURCE_DIR}/share/id_rsa_drop.ceph.com.pub


### PR DESCRIPTION
* NES rgw가 ranger jni 엔진을 사용할 수 있도록 JNI가 포함되면서 rados 라이브러리가 특정 JAVA 패키지와 특정 환경변수를 요구하게 되었다.
* 이러한 상황에 적절한 조치가 빠져있어서 패키지와 환경 변수를 사용자가 추가로 설치하고 설정해야 동작할 수 있음
* 이와 같은 상황이 발생하지 않도록 요구 패키지와 변수를 설치하면서 자동으로 준비해주는 조치를 추가하는 작업