### PR TITLE
[RND-1441] NES cpeh-mgr의 always_on_modules가 비어있는 버그 해결

### DIFF
--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -55,6 +55,18 @@ const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
     }
   },
   {
+    CEPH_RELEASE_APEX, {
+      "crash",
+      "status",
+      "progress",
+      "balancer",
+      "devicehealth",
+      "orchestrator_cli",
+      "rbd_support",
+      "volumes",
+    }
+  },
+  {
     CEPH_RELEASE_OCTOPUS, {
       "crash",
       "status",
@@ -416,7 +428,7 @@ public:
     mm(a), op(c) {}
   void finish(int r) override {
     if (r >= 0) {
-      // Success 
+      // Success
     } else if (r == -ECANCELED) {
       mm->mon->no_reply(op);
     } else {

--- a/src/mon/MgrMonitor.cc
+++ b/src/mon/MgrMonitor.cc
@@ -79,6 +79,20 @@ const static std::map<uint32_t, std::set<std::string>> always_on_modules = {
       "pg_autoscaler",
       "telemetry",
     }
+  },
+  {
+    CEPH_RELEASE_BELFRY, {
+      "crash",
+      "status",
+      "progress",
+      "balancer",
+      "devicehealth",
+      "orchestrator",
+      "rbd_support",
+      "volumes",
+      "pg_autoscaler",
+      "telemetry",
+    }
   }
 };
 


### PR DESCRIPTION
* "ceph mgr module ls" 명령을 입력하면 ceph mgr의 모듈의 목록이 상태와 함께 출력된다.
* 이 때 항상 떠있어야 하는 모듈은 always_on_modules에 위치하는데, 이 목록이 비어서 출력된다는 것을 발견했다.
* 이전 버전부터 있었던 버그로 Apex에도 패치를 적용해야 한다.