### PR TITLE
[RND-1599] atlassian_statuspage 매니저 모듈에서 인코딩 관련 이슈로 동작을 멈추는 문제 해결

### DIFF
--- a/src/pybind/mgr/atlassian_statuspage/module.py
+++ b/src/pybind/mgr/atlassian_statuspage/module.py
@@ -340,11 +340,11 @@ class AtlassianStatuspage(MgrModule):
             response = requests.put(request_url, headers=headers, json=data)
 
         self.log.debug("request url is '%s'" % request_url)
-        self.log.debug("response of rest: [%d] %s" % (response.status_code, response.text.encode('utf8')))
+        self.log.debug("response of rest: [%d] %s" % (response.status_code, response.text))
 
         if incident_id != '' \
           and response.status_code == 422 \
-          and "Too many incident updates" in response.text.encode('utf8'):
+          and "Too many incident updates" in response.text:
             data['incident']['status'] = "resolved"
             data['incident'][ 'body' ] = "Too many updates in incident. Relsolve this incident and continue in new incident."
             response = requests.put(request_url, headers=headers, json=data)


### PR DESCRIPTION
* atlassian_statuspage 모듈에서 인코딩 에러를 발생시키며 동작을 멈추는 문제가 발견됨
* 2.0.0.nes 버전에서 ceph-mgr이 사용하는 python의 버전을 2에서 3으로 변경하면서 생겨난 문제로 보임
* 해당 문제를 해결하는 일감
* 관련 JIRA: https://jira.nexr.kr/browse/RND-1599