### PR TITLE
[RND-1600] crash 매니저 모듈에서 인코딩 관련 이슈로 동작을 멈추는 문제 해결

### DIFF
--- a/src/pybind/mgr/crash/module.py
+++ b/src/pybind/mgr/crash/module.py
@@ -166,7 +166,7 @@ class Module(MgrModule):
             sig.update(func.encode())
         if assert_msg:
             sig.update(self.sanitize_assert_msg(assert_msg).encode())
-        return ''.join('%02x' % ord(c) for c in sig.digest())
+        return ''.join('%02x' % ord(c) for c in str(sig.digest()))
 
     # command handlers
 


### PR DESCRIPTION
* crash 모듈에서 인코딩 에러를 발생시키며 동작을 멈추는 문제가 발견됨
* 2.0.0.nes 버전에서 ceph-mgr이 사용하는 python의 버전을 2에서 3으로 변경하면서 생겨난 문제로 보임
* 해당 문제를 해결하는 일감
* 관련 JIRA: https://jira.nexr.kr/browse/RND-1600