### PR TITLE
[RND-1601] NES dashboard 요청 실패시 CORS 처리 추가

### DIFF
--- a/src/pybind/mgr/dashboard/module.py
+++ b/src/pybind/mgr/dashboard/module.py
@@ -193,9 +193,11 @@ class CherryPyConfig(object):
         """
         cross_origin_url = mgr.get_localized_module_option('cross_origin_url', '')
         if cross_origin_url:
-            cherrypy.tools.CORS = cherrypy.Tool('before_handler', self.cors_tool)
+            cherrypy.tools.CORS     = cherrypy.Tool('before_handler', self.cors_tool)
+            cherrypy.tools.CORS_FIN = cherrypy.Tool('before_finalize', self.cors_tool)
             config = {
-                'tools.CORS.on': True,
+                'tools.CORS.on':     True,
+                'tools.CORS_FIN.on': True,
             }
             self.update_cherrypy_config(config)
 


### PR DESCRIPTION
* NES dashboard에서 CORS를 처리할 때 실패한 요청에 대한 CORS를 처리가 빠져있음.
* 이 처리를 추가하는 일감
* 관련 JIRA: https://jira.nexr.kr/browse/RND-1601