### PR TITLE
[RND-1602] rgw의 ranger JNI 바이너리 기본 경로 수정

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -6020,7 +6020,7 @@ std::vector<Option> get_rgw_options() {
     .set_description("The directory path to jni class files."),
 
     Option("rgw_ranger_jni_engine_jar", Option::TYPE_STR, Option::LEVEL_ADVANCED)
-    .set_default("/usr/share/ceph/rgw/ranger/jni/nesRangerEngine.jar")
+    .set_default("/usr/share/ceph/rgw/ranger/engine/nesRangerEngine.jar")
     .set_description("The file path to jni engine jar."),
 
     Option("rgw_ranger_audit_url", Option::TYPE_STR, Option::LEVEL_ADVANCED)


### PR DESCRIPTION
* rgw ranger jni 엔진의 기본 경로가 잘못 설정되어 있음
  * as-is: `rgw_ranger_jni_engine_jar=/usr/share/ceph/rgw/ranger/jni/nesRangerEngine.jar`
  * to-be: `rgw_ranger_jni_engine_jar=/usr/share/ceph/rgw/ranger/engine/nesRangerEngine.jar`
 * 이를 바로 잡는 작업
 * 관련 JIRA: https://jira.nexr.kr/browse/RND-1602