### PR TITLE
[RND-1603] NES ranger 인가 정책 연동에 특수 문자가 포함된 사용자 지원 추가

### DIFF
--- a/src/pybind/mgr/objstore_usersync/module.py
+++ b/src/pybind/mgr/objstore_usersync/module.py
@@ -550,13 +550,17 @@ class ObjstoreUsersync(MgrModule):
             endp_key = user_name if user_name in self.endpoint_map['ranger'] else '_default'
             endpoint = self.endpoint_map['ranger'][endp_key]
 
-        resp, scode = self._request_ranger_rest("get", "/service/plugins/services/name/" + str(user_name), endpoint)
+        service_name = user_name
+        service_name = re.sub("@", "_at_", service_name)
+        service_name = re.sub("\.", "_dot_", service_name)
+
+        resp, scode = self._request_ranger_rest("get", "/service/plugins/services/name/" + str(service_name), endpoint)
         is_success = (scode == 200 or scode == 404)
         is_service_exist = (scode == 200)
         is_service_enabled = (is_service_exist and resp['isEnabled'] == True)
 
         if not is_success:
-            self.log.warning("Failed to get service of '%s'" % user_name)
+            self.log.warning("Failed to get service of '%s'" % service_name)
             return is_success
 
         service_endpoint = self.ranger_service_initial_endpoint
@@ -580,7 +584,7 @@ class ObjstoreUsersync(MgrModule):
 
         if not is_service_exist:
             service_define_data = {
-                'name': s3_key_info['user'],
+                'name': service_name,
                 'type': 's3',
                 'description': "created by nes. " \
                              + "If want to change initail endpoint, " \
@@ -602,7 +606,7 @@ class ObjstoreUsersync(MgrModule):
 
             owner_policy_data = {
                 'name': 'nes_default_policy',
-                'service': user_name,
+                'service': service_name,
                 'description': 'created by nes.',
                 'resources': {
                     'path': {
@@ -626,7 +630,7 @@ class ObjstoreUsersync(MgrModule):
             is_success  = (scode == 200)
 
             if not is_success:
-                self.log.warning("Failed to create default owner_policy of '%s'" % user_name)
+                self.log.warning("Failed to create default owner_policy of '%s'" % service_name)
                 return is_success
 
         elif not is_service_enabled:
@@ -666,13 +670,17 @@ class ObjstoreUsersync(MgrModule):
             endp_key = user_name if user_name in self.endpoint_map['ranger'] else '_default'
             endpoint = self.endpoint_map['ranger'][endp_key]
 
-        resp, scode = self._request_ranger_rest("get", "/service/plugins/services/name/" + str(user_name), endpoint)
+        service_name = user_name
+        service_name = re.sub("@", "_at_", service_name)
+        service_name = re.sub("\.", "_dot_", service_name)
+
+        resp, scode = self._request_ranger_rest("get", "/service/plugins/services/name/" + str(service_name), endpoint)
         is_success = (scode == 200 or scode == 404)
         is_service_exist = (scode == 200)
         is_service_enabled = (is_service_exist and resp['isEnabled'] == True)
 
         if not is_success:
-            self.log.warning("Failed to get s3 service of '%s'" % user_name)
+            self.log.warning("Failed to get s3 service of '%s'" % service_name)
             return is_success
 
         if is_service_enabled:
@@ -682,7 +690,7 @@ class ObjstoreUsersync(MgrModule):
             is_success  = (scode == 200)
 
             if not is_success:
-                self.log.warning("Failed to disable s3 service of '%s'" % user_name)
+                self.log.warning("Failed to disable s3 service of '%s'" % service_name)
                 return is_success
 
         return is_success

--- a/src/rgw/rgw_ranger.h
+++ b/src/rgw/rgw_ranger.h
@@ -6,6 +6,7 @@
 #include "rgw_http_client.h"
 
 #include <jni.h>
+#include <regex>
 
 #define dout_context g_ceph_context
 #define dout_subsys ceph_subsys_rgw
@@ -117,6 +118,14 @@ protected:
 
   string policy_cache_dir;
   time_t cache_update_interval;
+
+  string change_owner_to_svc_name(string owner_name) {
+    string svc_name = owner_name;
+    svc_name = regex_replace(svc_name, regex("@"), "_at_");
+    svc_name = regex_replace(svc_name, regex("\\."), "_dot_");
+    ldout(cct, 15) << __func__ << "(): owner '" << owner_name << "' change to '" << svc_name << "'" << dendl;
+    return svc_name;
+  }
 
 public:
   RGWRangerManager(CephContext* const _cct) : cct(_cct) {

--- a/src/rgw/rgw_ranger.h
+++ b/src/rgw/rgw_ranger.h
@@ -123,7 +123,7 @@ protected:
     string svc_name = owner_name;
     svc_name = regex_replace(svc_name, regex("@"), "_at_");
     svc_name = regex_replace(svc_name, regex("\\."), "_dot_");
-    ldout(cct, 15) << __func__ << "(): owner '" << owner_name << "' change to '" << svc_name << "'" << dendl;
+    ldout(cct, 20) << __func__ << "(): owner '" << owner_name << "' refers the '" << svc_name << "' ranger service" << dendl;
     return svc_name;
   }
 

--- a/src/rgw/rgw_ranger_jni.cc
+++ b/src/rgw/rgw_ranger_jni.cc
@@ -162,7 +162,7 @@ int RGWRangerJniManager::is_access_allowed(RGWUserEndpoint endp, RGWOp *& op, re
 
   rgw_user bucket_owner = s->bucket_owner.get_id();
 
-  string service_name = bucket_owner.to_str();
+  string service_name = change_owner_to_svc_name(bucket_owner.to_str());
 
  if ( (use_cached_one && can_i_use_cached_policy(service_name)) \
    || (!is_connection_ok(endp)) )

--- a/src/rgw/rgw_ranger_native.cc
+++ b/src/rgw/rgw_ranger_native.cc
@@ -2,7 +2,6 @@
 
 #include "include/ipaddr.h"
 
-#include <regex>
 #include <fstream>
 
 RGWRangerNativeManager* rgw_rnm = nullptr;
@@ -831,7 +830,7 @@ int RGWRangerNativeManager::is_access_allowed(RGWUserEndpoint endpoint, RGWOp *&
   const string bucket_owner = s->bucket_owner.get_id().to_str();
 
   vector<ranger_policy> related_policies;
-  int ret = get_related_policies(related_policies, endpoint, s, bucket_owner);
+  int ret = get_related_policies(related_policies, endpoint, s, change_owner_to_svc_name(bucket_owner));
   if (ret != 0) {
     ldpp_dout(op, 2) << __func__ << "(): Failed to get related policies" << dendl;
     return ret;


### PR DESCRIPTION
* NES ranger 인가 정책 연동시에 ranger의 정책은 rgw 사용자의 이름을 식별자로 하여 생성됨
* 하지만 ranger 정책의 식별자에는 특수 문자가 포함될 수 없다.
* 따라서, 특수 문자가 포함된 사용자는 ranger 인가 정책을 사용할 수 없게된다.
* 이 일감은 특수 문자가 포함된 사용자에 대한 ranger 인가 정책 연동 지원을 추가한다.
* 관련 JIRA: http://jira.nexrcorp.com/browse/RND-1603
