### PR TITLE
[RND-1605] NES ranger 인가 정책 연동에 사용하는 파일 처리 방식 디버그

### DIFF
--- a/src/rgw/rgw_ranger.cc
+++ b/src/rgw/rgw_ranger.cc
@@ -110,7 +110,7 @@ void prepare_cache_dir(CephContext* const cct) {
 
   struct stat f_stat;
   if (stat(ranger_cache_dir.c_str(), &f_stat) != 0) {
-    if (mkdir(ranger_cache_dir.c_str(), 0755) == -1) {
+    if (mkdir(ranger_cache_dir.c_str(), 0755) != -1) {
       chown(ranger_cache_dir.c_str(), cct->get_set_uid(), cct->get_set_gid());
     }
     else {

--- a/src/rgw/rgw_ranger.h
+++ b/src/rgw/rgw_ranger.h
@@ -117,6 +117,8 @@ protected:
 
   string policy_cache_dir;
   time_t cache_update_interval;
+  // cache_update
+  std::mutex cu_mutex;
 
 public:
   RGWRangerManager(CephContext* const _cct) : cct(_cct) {
@@ -215,6 +217,8 @@ protected:
   std::mutex r_mutex;
   std::condition_variable r_cond;
 
+  // audit_config
+  std::mutex ac_mutex;
 
 public:
   bool down_flag = false;

--- a/src/rgw/rgw_ranger_jni.cc
+++ b/src/rgw/rgw_ranger_jni.cc
@@ -326,6 +326,8 @@ bool RGWRangerJniThread::config_audit()
 
   string target_audit_conf = (audit_service_specific) ? service_audit_conf : default_audit_conf;
 
+  unique_lock<std::mutex> ac_lock(ac_mutex);
+
   if (parent->is_file_age_younger(target_audit_conf, parent->audit_conf_age))
   {
     return true;
@@ -466,6 +468,8 @@ void RGWRangerJniThread::organize_cached_policy() {
   string dest_file = cache_dir + "/" + service + ".json";
 
   std::remove(cached_role.c_str());
+
+  unique_lock<std::mutex> cu_lock(parent->cu_mutex);
 
   if (parent->is_file_age_younger(dest_file, parent->cache_update_interval))
   {

--- a/src/rgw/rgw_ranger_jni.cc
+++ b/src/rgw/rgw_ranger_jni.cc
@@ -20,7 +20,7 @@ RGWRangerJniManager::RGWRangerJniManager(CephContext* const _cct, rgw::sal::RGWR
 
   struct stat f_stat;
   if (stat(jni_config_dir.c_str(), &f_stat) != 0) {
-    if (mkdir(jni_config_dir.c_str(), 0755) == -1) {
+    if (mkdir(jni_config_dir.c_str(), 0755) != -1) {
       chown(jni_config_dir.c_str(), cct->get_set_uid(), cct->get_set_gid());
     }
     else {


### PR DESCRIPTION
* NES가 ranger 인가 정책 연동에 사용하는 파일은 /var/lib/ceph/radosgw/{ranger_cache,ranger_conf} 디렉토리의 파일들이다.
* 디버깅1: 관련 디렉토리의 소유자 설정 누락
만약 관련 디렉토리가 없으면 NES rgw가 구동될 때 새로 만들어 주는데, 이때 해당 디렉토리의 소유자가 ceph로 설정되지 않아 이후 동작에 지장을 주는 현상을 발견했다.
이와 같은 현상을 바로 잡는다.
* 디버깅2: 파일 조작 과정의 상호 배제 기법(mutex) 추가
해당 디렉토리의 파일들을 조작할 때 상호 배제 기법(mutex)이 적용되지 않아서 여러 쓰레드에서 같은 파일에 대한 동시 접근이 일어날 수 있다.
따라서 파일 조작시 상호 배제 기법을 적용한다.
* 관련 JIRA: http://jira.nexrcorp.com/browse/RND-1605
