### PR TITLE
[NES-8] NES의 writeback 캐시 티어 읽기 쓰기 동작 조정

### DIFF
--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -2494,7 +2494,7 @@ std::vector<Option> get_global_options() {
     .set_description("how frequently to retry recovery reservations after being denied (e.g., due to a full OSD)"),
 
     Option("osd_agent_max_ops", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(4)
+    .set_default(8)
     .set_description("maximum concurrent tiering operations for tiering agent"),
 
     Option("osd_agent_max_low_ops", Option::TYPE_INT, Option::LEVEL_ADVANCED)

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2797,9 +2797,11 @@ PrimaryLogPG::cache_result_t PrimaryLogPG::maybe_handle_cache_detail(
       int first_opcode = first_op.op.op;
 
       // Promote object if target object was not new one
-      if (first_opcode != CEPH_OSD_OP_CREATE &&
-          first_opcode != CEPH_OSD_OP_WRITE &&
-          first_opcode != CEPH_OSD_OP_WRITEFULL)
+      if (first_opcode != CEPH_OSD_OP_SETALLOCHINT &&
+          first_opcode != CEPH_OSD_OP_WRITEFULL &&
+          first_opcode != CEPH_OSD_OP_SETXATTR &&
+          first_opcode != CEPH_OSD_OP_OMAPSETVALS &&
+          first_opcode != CEPH_OSD_OP_OMAPSETHEADER)
       {
         promote_object(obc, missing_oid, oloc, op, promote_obc);
       }

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -2791,16 +2791,21 @@ PrimaryLogPG::cache_result_t PrimaryLogPG::maybe_handle_cache_detail(
     }
 
     if (op->may_write() || op->may_cache()) {
-      do_proxy_write(op);
+      // Prepare to check first osd operation
+      vector<OSDOp> ops = m->ops;
+      OSDOp& first_op = *(ops.begin());
+      int first_opcode = first_op.op.op;
 
-      // Promote too?
-      if (!op->need_skip_promote() && 
-          maybe_promote(obc, missing_oid, oloc, in_hit_set,
-	              pool.info.min_write_recency_for_promote,
-		      OpRequestRef(),
-		      promote_obc)) {
-	return cache_result_t::BLOCKED_PROMOTE;
+      // Promote object if target object was not new one
+      if (first_opcode != CEPH_OSD_OP_CREATE &&
+          first_opcode != CEPH_OSD_OP_WRITE &&
+          first_opcode != CEPH_OSD_OP_WRITEFULL)
+      {
+        promote_object(obc, missing_oid, oloc, op, promote_obc);
       }
+
+      do_proxy_write(op, NULL, true); // self proxy write
+
       return cache_result_t::HANDLED_PROXY;
     } else {
       do_proxy_read(op);
@@ -3037,7 +3042,7 @@ struct C_ProxyChunkRead : public Context {
   }
 };
 
-void PrimaryLogPG::do_proxy_read(OpRequestRef op, ObjectContextRef obc)
+void PrimaryLogPG::do_proxy_read(OpRequestRef op, ObjectContextRef obc, bool self)
 {
   // NOTE: non-const here because the ProxyReadOp needs mutable refs to
   // stash the result in the request's OSDOp vector
@@ -3058,7 +3063,12 @@ void PrimaryLogPG::do_proxy_read(OpRequestRef op, ObjectContextRef obc)
   /* proxy */
     soid = m->get_hobj();
     oloc = object_locator_t(m->get_object_locator());
-    oloc.pool = pool.info.tier_of;
+    if (self) {
+      oloc.hash = soid.get_hash();
+    }
+    else {
+      oloc.pool = pool.info.tier_of;
+    }
   }
   unsigned flags = CEPH_OSD_FLAG_IGNORE_CACHE | CEPH_OSD_FLAG_IGNORE_OVERLAY;
 
@@ -3249,7 +3259,7 @@ struct C_ProxyWrite_Commit : public Context {
   }
 };
 
-void PrimaryLogPG::do_proxy_write(OpRequestRef op, ObjectContextRef obc)
+void PrimaryLogPG::do_proxy_write(OpRequestRef op, ObjectContextRef obc, bool self)
 {
   // NOTE: non-const because ProxyWriteOp takes a mutable ref
   MOSDOp *m = static_cast<MOSDOp*>(op->get_nonconst_req());
@@ -3270,7 +3280,12 @@ void PrimaryLogPG::do_proxy_write(OpRequestRef op, ObjectContextRef obc)
   /* proxy */
     soid = m->get_hobj();
     oloc = object_locator_t(m->get_object_locator());
-    oloc.pool = pool.info.tier_of;
+    if (self) {
+      oloc.hash = soid.get_hash();
+    }
+    else {
+      oloc.pool = pool.info.tier_of;
+    }
   }
 
   unsigned flags = CEPH_OSD_FLAG_IGNORE_CACHE | CEPH_OSD_FLAG_IGNORE_OVERLAY;

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1465,7 +1465,7 @@ protected:
   // -- proxyread --
   map<ceph_tid_t, ProxyReadOpRef> proxyread_ops;
 
-  void do_proxy_read(OpRequestRef op, ObjectContextRef obc = NULL);
+  void do_proxy_read(OpRequestRef op, ObjectContextRef obc = NULL, bool self = false);
   void finish_proxy_read(hobject_t oid, ceph_tid_t tid, int r);
   void cancel_proxy_read(ProxyReadOpRef prdop, vector<ceph_tid_t> *tids);
 
@@ -1474,7 +1474,7 @@ protected:
   // -- proxywrite --
   map<ceph_tid_t, ProxyWriteOpRef> proxywrite_ops;
 
-  void do_proxy_write(OpRequestRef op, ObjectContextRef obc = NULL);
+  void do_proxy_write(OpRequestRef op, ObjectContextRef obc = NULL, bool self = false);
   void finish_proxy_write(hobject_t oid, ceph_tid_t tid, int r);
   void cancel_proxy_write(ProxyWriteOpRef pwop, vector<ceph_tid_t> *tids);
 


### PR DESCRIPTION
- NES Writeback 캐시 티어의 쓰기 동작이 베이스 풀에 데이터 쓰고 캐시 풀에 올리는 (promote) 방식으로 동작하고 있던 것을 발견했다.
- 이 동작은 의도한 동작과 정 반대이므로 해당 동작을 캐시 풀에 쓰고 베이스 풀에 비동기로 내리는 (non blocking flush) 방식으로 변경한다.
- 관련 지라: https://jira.nexr.kr/browse/NES-8#