### PR TITLE
[NES-9] NES의 writeback 캐시 티어 쓰기 동작 조정 이후 rados 엔진 인덱싱 이슈 해결

### DIFF
--- a/src/messages/MOSDOp.h
+++ b/src/messages/MOSDOp.h
@@ -235,6 +235,8 @@ public:
   }
 
   bool has_flag(__u32 flag) const { return flags & flag; };
+  void add_flag(__u32 flag) { flags |= flag; };
+  void set_flags(__u32 flags) { this->flags = flags; };
 
   bool is_retry_attempt() const { return flags & CEPH_OSD_FLAG_RETRY; }
   void set_retry_attempt(unsigned a) { 

--- a/src/osd/PrimaryLogPG.cc
+++ b/src/osd/PrimaryLogPG.cc
@@ -3048,6 +3048,11 @@ void PrimaryLogPG::do_proxy_read(OpRequestRef op, ObjectContextRef obc, bool sel
   // NOTE: non-const here because the ProxyReadOp needs mutable refs to
   // stash the result in the request's OSDOp vector
   MOSDOp *m = static_cast<MOSDOp*>(op->get_nonconst_req());
+  do_proxy_read(m, op, obc, self);
+}
+
+void PrimaryLogPG::do_proxy_read(MOSDOp *m, OpRequestRef op, ObjectContextRef obc, bool self)
+{
   object_locator_t oloc;
   hobject_t soid;
   /* extensible tier */
@@ -3276,6 +3281,11 @@ void PrimaryLogPG::do_proxy_write(OpRequestRef op, ObjectContextRef obc, bool se
 {
   // NOTE: non-const because ProxyWriteOp takes a mutable ref
   MOSDOp *m = static_cast<MOSDOp*>(op->get_nonconst_req());
+  do_proxy_write(m, op, obc, self, false);
+}
+
+void PrimaryLogPG::do_proxy_write(MOSDOp *m, OpRequestRef op, ObjectContextRef obc, bool self, bool is_custom_op)
+{
   object_locator_t oloc;
   SnapContext snapc(m->get_snap_seq(), m->get_snaps());
   hobject_t soid;
@@ -3325,6 +3335,7 @@ void PrimaryLogPG::do_proxy_write(OpRequestRef op, ObjectContextRef obc, bool se
     ProxyWriteOpRef pwop(std::make_shared<ProxyWriteOp>(op, soid, m->ops, m->get_reqid()));
     pwop->ctx = new OpContext(op, m->get_reqid(), &pwop->ops, this);
     pwop->mtime = m->get_mtime();
+    pwop->sent_reply = is_custom_op;
 
     ObjectOperation obj_op;
     obj_op.dup(pwop->ops);

--- a/src/osd/PrimaryLogPG.h
+++ b/src/osd/PrimaryLogPG.h
@@ -1466,6 +1466,7 @@ protected:
   map<ceph_tid_t, ProxyReadOpRef> proxyread_ops;
 
   void do_proxy_read(OpRequestRef op, ObjectContextRef obc = NULL, bool self = false);
+  void do_proxy_read(MOSDOp *m, OpRequestRef op, ObjectContextRef obc = NULL, bool self = false);
   void finish_proxy_read(hobject_t oid, ceph_tid_t tid, int r);
   void cancel_proxy_read(ProxyReadOpRef prdop, vector<ceph_tid_t> *tids);
 
@@ -1475,6 +1476,7 @@ protected:
   map<ceph_tid_t, ProxyWriteOpRef> proxywrite_ops;
 
   void do_proxy_write(OpRequestRef op, ObjectContextRef obc = NULL, bool self = false);
+  void do_proxy_write(MOSDOp *m, OpRequestRef op, ObjectContextRef obc = NULL, bool self = false, bool is_custom_op = true);
   void finish_proxy_write(hobject_t oid, ceph_tid_t tid, int r);
   void cancel_proxy_write(ProxyWriteOpRef pwop, vector<ceph_tid_t> *tids);
 


### PR DESCRIPTION
- [NES-8](http://jira.nexrcorp.com/browse/NES-8) 에서 적용한 writeback 캐시 티어의 쓰기 동작 조정 이후에 rados로 쓰기 및 복사를 수행했을 때 인덱스가 보이지 않는 이슈를 발견
  - 관련 PR: https://github.com/nexr/ceph/pull/48
- 예를 들면, `rados put -p <base_pool> obj1 data` 명령으로 obj1 쓰기 했을 때 `rados ls -p <base_pool> | grep obj1` 하면 아무 결과도 나오지 않는 문제
- 이전에는 base_pool에 쓰고 cache_pool로 promote 했기 때문에 데이터를 쓰면 쓰는 대로 base_pool에 오브젝트가 있었는데, cache_pool에 처음 쓰도록 변경하여 cache_pool에만 오브젝트가 있는 경우 base_pool에서 해당 오브젝트를 조회할 수 없게 되는 것이 원인
- 필요한 경우 쓰기 동작 이후 base_pool에도 오브젝트를 생성하도록 동작을 변경해야 한다.
- 쓰기 직후 base_pool에 오브젝트를 넣는 동작이 쓰기 동작 조정으로 얻은 성능 이점을 낮출 수 있기 때문에 성능 저하도 최소화 할 필요가 있다.
