### PR TITLE
[NES-20] NES 오브젝트 스토어 오브젝트 삭제 성능 개선

### DIFF
--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -6740,6 +6740,7 @@ wrap_up:
 
     rgw_obj obj = each_obj_delete->target->get_obj();
 
+    // The send_partial_response() is placed outside threads because it can't be performed simultaneously.
     send_partial_response(obj.key, each_obj_delete->result.delete_marker, each_obj_delete->result.version_id, each_op_ret);
 
     delete each_obj_delete->target;


### PR DESCRIPTION
* 오브젝트 스토어의 오브젝트가 많을 때 버켓이나 다중 오브젝트 삭제가 너무 오래 걸린다는 불만 사항이 있음
* 삭제 성능을 개선할 수 있는 방안을 고안하여 적용한다.
* 관련 Jira: http://jira.nexrcorp.com/projects/NES/issues/NES-20