### PR TITLE
[NES-28] NES 오브젝트 스토어 삭제 루틴에 쓰레드 풀 적용

### DIFF
--- a/src/common/Thread.h
+++ b/src/common/Thread.h
@@ -106,7 +106,6 @@ public:
   ~ThreadLambda() {
     if (is_started()) {
       stop();
-      detach();
     }
   }
 
@@ -114,10 +113,16 @@ public:
   void set_param(Params... _params) { params = std::make_tuple(_params...); }
 
   bool is_done() { return done; }
-  void reset_done() {
-    done = false;
-    if (is_started()) {
-      detach();
+  bool reset_done() {
+    if (done) {
+      stop();
+
+      done = false;
+
+      return true;
+    }
+    else {
+      return false;
     }
   }
 
@@ -149,7 +154,9 @@ public:
 
   void restart() {
     stop();
-    reset_done();
+
+    done = false;
+
     start();
   }
 

--- a/src/common/WorkQueue.h
+++ b/src/common/WorkQueue.h
@@ -747,6 +747,54 @@ public:
 
 };
 
+// The "void" ReturnType is not implemented... Use "void*" instaed.
+template<typename ReturnType, typename ... Params>
+class ThreadLambdaPool {
+  using TLclass = ThreadLambda<ReturnType, Params ...>;
+  vector<TLclass *> threads;
+
+  using Lambda = std::function<ReturnType (Params ...)>;
+  Lambda lambda_template = NULL;
+
+  size_t size = 1000;
+  size_t next_tid = 0;
+
+  // run
+  std::mutex r_mutex;
+
+public:
+  ThreadLambdaPool(Lambda&& _lambda_template, unsigned int _size = 1000) : lambda_template(_lambda_template), size(_size)
+  {
+    for (size_t create_count = 0; create_count < size; create_count++) {
+      TLclass* new_thread = new TLclass(std::move(lambda_template));
+      threads.push_back(new_thread);
+    }
+  }
+
+  ~ThreadLambdaPool()
+  {
+    for (TLclass* each_thread: threads) {
+      each_thread->wait_done();
+      delete each_thread;
+    }
+  }
+
+  void run(Params... _params) {
+    unique_lock<std::mutex> r_lock(r_mutex);
+
+    TLclass* allocated_thread = threads[next_tid];
+
+    allocated_thread->wait_done();
+
+    allocated_thread->reset_done();
+    allocated_thread->set_param(_params ...);
+
+    allocated_thread->start();
+
+    next_tid = (next_tid + 1) % size;
+  }
+};
+
 #endif
 
 #endif

--- a/src/common/legacy_config_opts.h
+++ b/src/common/legacy_config_opts.h
@@ -1573,6 +1573,7 @@ OPTION(rgw_swift_need_stats, OPT_BOOL) // option to enable stats on bucket listi
 OPTION(rgw_acl_grants_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html), An ACL can have up to 100 grants.
 OPTION(rgw_cors_rules_max_num, OPT_INT) // According to AWS S3(http://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html), An cors can have up to 100 rules.
 OPTION(rgw_delete_multi_obj_max_num, OPT_INT) // According to AWS S3(https://docs.aws.amazon.com/AmazonS3/latest/dev/DeletingObjects.html), Amazon S3 also provides the Multi-Object Delete API that you can use to delete up to 1000 objects in a single HTTP request.
+OPTION(rgw_delete_thread_num, OPT_INT) // The number of threads that process objects deletion
 OPTION(rgw_website_routing_rules_max_num, OPT_INT) // According to AWS S3, An website routing config can have up to 50 rules.
 OPTION(rgw_sts_entry, OPT_STR)
 OPTION(rgw_sts_key, OPT_STR)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5485,7 +5485,13 @@ std::vector<Option> get_rgw_options() {
 
     Option("rgw_delete_multi_obj_max_num", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(1000)
-    .set_description("Max number of objects in a single multi-object delete request"),
+    .set_description("Max number of objects in a single multi-object delete request")
+    .add_see_also({"rgw_delete_thread_num"}),
+
+    Option("rgw_delete_thread_num", Option::TYPE_INT, Option::LEVEL_ADVANCED)
+    .set_default(256)
+    .set_description("The number of threads that process objects deletion")
+    .set_flag(Option::FLAG_STARTUP),
 
     Option("rgw_website_routing_rules_max_num", Option::TYPE_INT, Option::LEVEL_ADVANCED)
     .set_default(50)

--- a/src/common/options.cc
+++ b/src/common/options.cc
@@ -5489,7 +5489,7 @@ std::vector<Option> get_rgw_options() {
     .add_see_also({"rgw_delete_thread_num"}),
 
     Option("rgw_delete_thread_num", Option::TYPE_INT, Option::LEVEL_ADVANCED)
-    .set_default(256)
+    .set_default(1024)
     .set_description("The number of threads that process objects deletion")
     .set_flag(Option::FLAG_STARTUP),
 

--- a/src/rgw/rgw_op.cc
+++ b/src/rgw/rgw_op.cc
@@ -22,6 +22,7 @@
 #include "common/utf8.h"
 #include "common/ceph_json.h"
 #include "common/static_ptr.h"
+#include "common/WorkQueue.h"
 
 #include "rgw_rados.h"
 #include "rgw_zone.h"
@@ -6550,15 +6551,65 @@ void RGWDeleteMultiObj::pre_exec()
   rgw_bucket_object_pre_exec(s);
 }
 
+using ThreadObjDelPool = ThreadLambdaPool<int, req_state*, rgw::sal::RGWRadosStore*, RGWRados::Object::Delete*, map<rgw_obj_key, RGWRados::Object::Delete*>*, std::mutex*>;
 void RGWDeleteMultiObj::execute()
 {
+  // map_update
+  std::mutex mu_mutex;
+
+  static ThreadObjDelPool* tod_pool;
+  if (tod_pool == nullptr) {
+    int tp_size = s->cct->_conf->rgw_delete_thread_num;
+    tod_pool = new ThreadObjDelPool(
+      [](req_state* s, rgw::sal::RGWRadosStore* store, RGWRados::Object::Delete* del_op, map<rgw_obj_key, RGWRados::Object::Delete*>* result_map, std::mutex* mu_mutex) -> int {
+        rgw_obj obj = del_op->target->get_obj();
+
+        del_op->params.bucket_owner = s->bucket_owner.get_id();
+        del_op->params.versioning_status = s->bucket_info.versioning_status();
+        del_op->params.obj_owner = s->owner;
+
+        int op_ret = 0;
+
+        op_ret = del_op->delete_obj(null_yield);
+        if (op_ret == -ENOENT) {
+          op_ret = 0;
+        }
+
+        del_op->result.op_ret = op_ret;
+
+        {
+          unique_lock<std::mutex> mu_lock(*mu_mutex);
+          result_map->insert(make_pair(obj.key, del_op));
+        }
+
+        const auto obj_state = s->obj_ctx->get_state(obj);
+
+        bufferlist etag_bl;
+        const auto etag = obj_state->get_attr(RGW_ATTR_ETAG, etag_bl) ? etag_bl.to_str() : "";
+
+        const auto ret = rgw::notify::publish(s, obj.key, obj_state->size, obj_state->mtime, etag,
+            del_op->result.delete_marker && s->object.instance.empty() ? rgw::notify::ObjectRemovedDeleteMarkerCreated : rgw::notify::ObjectRemovedDelete,
+            store);
+        if (ret < 0) {
+          ldpp_dout(s, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
+          // TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
+            // this should be global conf (probably returnign a different handler)
+            // so we don't need to read the configured values before we perform it
+        }
+
+        ldpp_dout(s, 10) << "Delete " << obj.key << "!" << dendl;
+        return op_ret;
+      },
+      tp_size
+    );
+  }
+
   RGWMultiDelDelete *multi_delete;
   vector<rgw_obj_key>::iterator iter;
   RGWMultiDelXMLParser parser;
   RGWObjectCtx *obj_ctx = static_cast<RGWObjectCtx *>(s->obj_ctx);
 
-  using ThreadObjDelete = ThreadLambda<int, RGWDeleteMultiObj*, RGWRados::Object::Delete*>;
-  queue<ThreadObjDelete *> q_tods;
+  map<rgw_obj_key, RGWRados::Object::Delete*> result_map;
 
   char* buf;
 
@@ -6618,9 +6669,7 @@ void RGWDeleteMultiObj::execute()
     goto wrap_up;
   }
 
-  for (iter = multi_delete->objects.begin();
-        iter != multi_delete->objects.end();
-        ++iter) {
+  for (iter = multi_delete->objects.begin(); iter != multi_delete->objects.end(); ++iter) {
     rgw_obj obj(bucket, *iter);
     if (s->iam_policy || ! s->iam_user_policies.empty()) {
       auto usr_policy_res = eval_user_policies(s->iam_user_policies, s->env,
@@ -6680,49 +6729,7 @@ void RGWDeleteMultiObj::execute()
     RGWRados::Object* del_target = new RGWRados::Object(store->getRados(), s->bucket_info, *obj_ctx, obj);
     RGWRados::Object::Delete* del_op = new RGWRados::Object::Delete(del_target);
 
-    ldpp_dout(this, 20) << "NOTICE: make ThreadObjDelete" << dendl;
-    ThreadObjDelete* each_tod = new ThreadObjDelete(
-      [](RGWDeleteMultiObj* self, RGWRados::Object::Delete* del_op) -> int
-      {
-        rgw::sal::RGWRadosStore* store = self->store;
-        req_state* s = self->s;
-
-        rgw_obj obj = del_op->target->get_obj();
-
-        del_op->params.bucket_owner = s->bucket_owner.get_id();
-        del_op->params.versioning_status = s->bucket_info.versioning_status();
-        del_op->params.obj_owner = s->owner;
-
-        int op_ret = del_op->delete_obj(null_yield);
-        if (op_ret == -ENOENT) {
-          op_ret = 0;
-        }
-
-        const auto obj_state = s->obj_ctx->get_state(obj);
-
-        bufferlist etag_bl;
-        const auto etag = obj_state->get_attr(RGW_ATTR_ETAG, etag_bl) ? etag_bl.to_str() : "";
-
-        const auto ret = rgw::notify::publish(s, obj.key, obj_state->size, obj_state->mtime, etag,
-                del_op->result.delete_marker && s->object.instance.empty() ? rgw::notify::ObjectRemovedDeleteMarkerCreated : rgw::notify::ObjectRemovedDelete,
-                store);
-
-        if (ret < 0) {
-          ldpp_dout(s, 5) << "WARNING: publishing notification failed, with error: " << ret << dendl;
-          // TODO: we should have conf to make send a blocking coroutine and reply with error in case sending failed
-          // this should be global conf (probably returnign a different handler)
-            // so we don't need to read the configured values before we perform it
-        }
-
-        ldpp_dout(s, 10) << "object deletion done!: " << obj << dendl;
-
-        return op_ret;
-      },
-      this, del_op
-    );
-
-    each_tod->start();
-    q_tods.push(each_tod);
+    tod_pool->run(s, store, del_op, &result_map, &mu_mutex);
   }
 
   /*  set the return code to zero, errors at this point will be
@@ -6730,13 +6737,22 @@ void RGWDeleteMultiObj::execute()
   op_ret = 0;
 
 wrap_up:
-  while (!q_tods.empty()) {
-    ThreadObjDelete* each_tod = q_tods.front();
+  for (iter = multi_delete->objects.begin(); iter != multi_delete->objects.end(); ++iter) {
+    rgw_obj_key each_obj_key = *iter;
 
-    each_tod->wait_done();
+    map<rgw_obj_key, RGWRados::Object::Delete*>::iterator found;
+    do {
+      found = result_map.find(each_obj_key);
+      if (found == result_map.end()) {
+        usleep(10);
+      }
+      else {
+        break;
+      }
+    } while (true);
 
-    RGWRados::Object::Delete* each_obj_delete = std::get<1>(each_tod->get_param());
-    int each_op_ret = each_tod->get_result();
+    RGWRados::Object::Delete* each_obj_delete = found->second;
+    int each_op_ret = each_obj_delete->result.op_ret;
 
     rgw_obj obj = each_obj_delete->target->get_obj();
 
@@ -6745,9 +6761,6 @@ wrap_up:
 
     delete each_obj_delete->target;
     delete each_obj_delete;
-
-    delete each_tod;
-    q_tods.pop();
   }
 
   (op_ret == 0) ? end_response() : send_status();

--- a/src/rgw/rgw_rados.h
+++ b/src/rgw/rgw_rados.h
@@ -857,6 +857,7 @@ public:
       struct DeleteResult {
         bool delete_marker;
         string version_id;
+        int op_ret;
 
         DeleteResult() : delete_marker(false) {}
       } result;


### PR DESCRIPTION
* 많은 양의 오브젝트 다중 삭제 요청이 한꺼번에 들어오는 경우 rgw 데몬에 crash가 발생함
* [NES-20](http://jira.nexrcorp.com/browse/NES-20) 에서 작업한 오브젝트 삭제 루틴의 쓰레드화가 원인
* 이러한 대량의 오브젝트 다중 삭제 요청에 의한 rgw 크래시를 해결하기 위해 쓰레드 풀을 적용한다.
* 관련 Jira: [NES-28](http://jira.nexrcorp.com/browse/NES-28) 