### PR TITLE
[NES-49] object lifecycle의 prefix 필터가 동작하지 않는 버그 해결

### DIFF
--- a/src/rgw/rgw_lc.cc
+++ b/src/rgw/rgw_lc.cc
@@ -2162,8 +2162,8 @@ std::string s3_expiration_header(
   for (const auto& ri : rule_map) {
     const auto& rule = ri.second;
     auto& id = rule.get_id();
-    auto& prefix = rule.get_prefix();
     auto& filter = rule.get_filter();
+    auto& prefix = filter.get_prefix();
     auto& expiration = rule.get_expiration();
     auto& noncur_expiration = rule.get_noncur_expiration();
 


### PR DESCRIPTION
* 오브젝트 스토어에 라이프 사이클의 prefix 필터가 동작하지 않는 버그를 발견했다.
* 이 버그를 해결하는 작업